### PR TITLE
fix: Disable unwanted language checks

### DIFF
--- a/terraform.json
+++ b/terraform.json
@@ -1,8 +1,21 @@
 {
     "extends": [
-      "config:base"
+      "config:base",
+      ":rebaseStalePrs"
     ],
     "semanticCommits": "enabled",
+    "java": {
+      "enabled": false
+    },
+    "js": {
+      "enabled": false
+    },
+    "python": {
+      "enabled": false
+    },
+    "node": {
+      "enabled": false
+    },
     "packageRules": [{
       "matchDatasources": [
         "terraform-module",


### PR DESCRIPTION
Renovate is primarily for Terraform, so disable Java, etc.